### PR TITLE
fix: Exclude banned dependencies (express)

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -15,6 +15,7 @@ export default [
 		files: ["**/*.test.js", "**/*.test.ts"],
 		rules: {
 			"e18e/prefer-static-regex": "off",
+			"e18e/ban-dependencies": "off",
 		},
 	},
 ];


### PR DESCRIPTION
Express is flagged as a banned dependency; but we need to test against express and it makes linting failing. Due to this excluding banned dependencies due to this.